### PR TITLE
Ersetzung des DWD Geoservers durch den DWD Geo Proxy

### DIFF
--- a/tmpl/default.php
+++ b/tmpl/default.php
@@ -100,7 +100,7 @@ $jsLocationname = str_replace("'", "\\'", $jsLocationname);
             });
 
             // Warnungs-Layer vom DWD-Geoserver
-            const warnlayer = L.tileLayer.betterWms("https://maps.dwd.de/geoserver/dwd/wms/", {
+            const warnlayer = L.tileLayer.betterWms("https://maps.dwd.de/geoproxy_warnungen/service/", {
                 layers: 'Warnungen_Gemeinden_vereinigt',
                 format: 'image/png',
                 transparent: true,
@@ -109,9 +109,10 @@ $jsLocationname = str_replace("'", "\\'", $jsLocationname);
             });
 
             // Layer mit neutraler Darstellung der Gemeinde-Warngebiete
-            const gemeindelayer = L.tileLayer.wms("https://maps.dwd.de/geoserver/dwd/wms/", {
+            const gemeindelayer = L.tileLayer.wms("https://maps.dwd.de/geoproxy_warnungen/service/", {
                 layers: 'Warngebiete_Gemeinden',
                 format: 'image/png',
+                styles: '',
                 transparent: true,
                 opacity: <?php echo (float) $params->get('opacity_communities', 0.4); ?>,
                 attribution: 'Geobasisdaten Gemeinden: &copy; <a href="https://www.bkg.bund.de" target="_blank">BKG</a> 2015 (Daten verändert)'


### PR DESCRIPTION
Nutzung des Geo-Proxy statt direktem Zugriff auf Geoserver gemäss Empfehlung von DWD.
https://www.dwd.de/DE/leistungen/webmodul_warnungen/webmodul_warnungen_hinweis_proxie.pdf?__blob=publicationFile&v=2
